### PR TITLE
Fix Train new command on windows

### DIFF
--- a/bin/commands/new.js
+++ b/bin/commands/new.js
@@ -24,7 +24,7 @@ module.exports = function (program) {
 
         boilerplate.generate(source, destination, function (err) {
             if (err) return console.error(err);
-            var install = ps.spawn('npm', ['install', (cmd.verbose ? '--verbose' : '')], {
+            var install = ps.spawn( (process.platform !== 'win32'?  'npm' : 'npm.cmd'), ['install', (cmd.verbose ? '--verbose' : '')], {
                 cwd:destination
             });
 


### PR DESCRIPTION
npm is launched as a batch file on Windows. This should fix the issue
16:
https://github.com/autoric/express-train/issues/16
