### PR TITLE
Only register js files

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -103,6 +103,12 @@ function traverseAndRegister(p, tree, aggregateOn, recurse) {
         }
     }
     else {
+
+        // only require js files
+        if (p.indexOf('.js') == -1) {
+            return;
+        }
+
         var loaded = require(p);
         if (_.isFunction(loaded)) {
             tree.register(key, loaded, {


### PR DESCRIPTION
If only js files were parsed it is possible to have some more files in the app directory. (e.g. the coffee sources or templates).

Bigger Applications manage themselves in "bundles" so there is everything in the app directory.
e.g.
app/UserBundle/UserController.js
app/UserBundle/User.js
app/UserBundle/Templates/UserList.hbs

This is only possible if we do not try to require other files.
