### PR TITLE
Added callback feature that fires before the first tree registration

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -19,63 +19,37 @@ module.exports = ExpressTrain;
  */
 ExpressTrain.version = package.version;
 
-/**
- * expose objects that can be overridden
- */
-var LOCATIONS = ExpressTrain.locations = {
-  config: {
-    path: '../config'
-  },
-  views: {
-    path: 'views'
-  },
-  pub: {
-    path: 'public'
-  },
-  models: {
-    path: 'models',
-    autoinject: true,
-    aggregateOn: 'models'
-  },
-  lib: {
-    path: 'lib',
-    autoinject: true
-  },
-  controllers: {
-    path: 'controllers',
-    autoinject: true
-  },
-  middleware: {
-    path: 'middleware',
-    autoinject: true
-  }
-};
 
 var DEFAULT_OPTIONS = ExpressTrain.options = {
   config: '../config',
   include: '**',
   exclude: null,  // file name starts with a dot
-  directories: []
-}
+  directories: [],
+  callbacks: {
+    onConfiguration: function(tree, config) { }
+  }
+};
 
 var DEFAULT_DIRECTORY_OPTIONS = {
   path : '',
   include : null,
   exclude : null,
   aggregateOn : null
-}
+};
 
 /**
  * Create a train application
  */
 function ExpressTrain(baseDir, opts) {
   var config,
-    opts = _.defaults((opts || {}), DEFAULT_OPTIONS),
+    opts        = _.defaults((opts || {}), DEFAULT_OPTIONS),
     directories = opts.directories,
-    tree = new nject.Tree();
+    callbacks   = opts.callbacks,
+    tree        = new nject.Tree();
 
   if(opts.config) {
     config = loadConfig(path.resolve(baseDir, opts.config));
+    callbacks.onConfiguration(tree, config);
     tree.constant('config', config);
   }
 
@@ -85,13 +59,15 @@ function ExpressTrain(baseDir, opts) {
       exclude = directoryConfig.exclude || opts.exclude || '',
       dirPath = path.resolve(baseDir, directoryConfig.path),
       aggregateOn = directoryConfig.aggregateOn,
-      stat = null
+      stat = null;
 
     try {
       stat = fs.statSync(dirPath);
     }
     catch (err) {
-      throw new Error('File or directory ' + dirPath + ' could not be found. Please check your application\'s `directories` configuration.');
+      throw new Error(
+        'File or directory ' + dirPath +
+         ' could not be found. Please check your application\'s `directories` configuration.');
     }
 
     function getFiles(patternList) {
@@ -133,46 +109,6 @@ function ExpressTrain(baseDir, opts) {
 
   return tree
 }
-
-//function traverseAndRegister(p, tree, aggregateOn, recurse) {
-//  var stat,
-//    key = path.basename(p, path.extname(p));
-//
-//  //ignore hidden files and directories
-//  if (key[0] == '.') return;
-//
-//  try {
-//    stat = fs.statSync(p);
-//  }
-//  catch (err) {
-//    throw new Error('File or directory ' + p + ' could not be found. Please check your application\'s `directories` configuration.');
-//  }
-//
-//  if (stat.isDirectory()) {
-//    if (recurse > 0) {
-//      var files = fs.readdirSync(p);
-//      files.forEach(function (file) {
-//        var filePath = path.join(p, file);
-//        traverseAndRegister(filePath, tree, aggregateOn, recurse - 1);
-//      });
-//    }
-//  }
-//  else {
-//    var loaded = require(p);
-//    if (_.isFunction(loaded)) {
-//      tree.register(key, loaded, {
-//        identifier: p,
-//        aggregateOn: aggregateOn
-//      });
-//    }
-//    else {
-//      tree.constant(key, loaded, {
-//        identifier: p,
-//        aggregateOn: aggregateOn
-//      });
-//    }
-//  }
-//}
 
 function loadConfig(p) {
   var configFile,


### PR DESCRIPTION
occurs.  This let's the calling code with the tree and the config so
that it can then register logging for anything internal that does a
large amount of non-trivial processing.

We were getting errors that were buried in the nject resolution and so
needed to add logging to nject, but the logging needed to flow out to
any log file which is configured with the configuration file
express-train provides by default.
